### PR TITLE
Add build-time version and git commit hash to home screen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,18 @@ reqwest_dav = { version = "0.2", default-features = false, features = [
     "rustls-tls",
 ] }
 
-[package]
-name = "stalltagebuch"
-version = "0.2.0"
+[workspace.package]
+version = "0.2.1"
 authors = ["Franz Dietrich <dietrich@teilgedanken.de>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
+
+[package]
+name = "stalltagebuch"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+fn main() {
+    // Re-run if HEAD or index changes so the hash stays fresh.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().chars().take(10).collect::<String>())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", hash);
+}

--- a/dioxus-gallery-components/Cargo.toml
+++ b/dioxus-gallery-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-gallery-components"
-version = "0.2.0"
+version.workspace = true
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A reusable photo gallery component for Dioxus"

--- a/nextcloud-auth/Cargo.toml
+++ b/nextcloud-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nextcloud-auth"
-version = "0.2.0"
+version.workspace = true
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Nextcloud Login Flow v2 authentication library with Dioxus UI components"

--- a/nextcloud-auth/src/service.rs
+++ b/nextcloud-auth/src/service.rs
@@ -44,7 +44,7 @@ impl NextcloudAuthService {
             .timeout(std::time::Duration::from_secs(60))
             .connect_timeout(std::time::Duration::from_secs(10))
             .tcp_keepalive(std::time::Duration::from_secs(30))
-            .user_agent("NextcloudAuth/0.1.0")
+            .user_agent(concat!("NextcloudAuth/", env!("CARGO_PKG_VERSION")))
             .build()
             .map_err(|e| AuthError::NetworkError(format!("Client build failed: {}", e)))?;
 
@@ -80,7 +80,7 @@ impl NextcloudAuthService {
             .timeout(std::time::Duration::from_secs(30))
             .connect_timeout(std::time::Duration::from_secs(10))
             .tcp_keepalive(std::time::Duration::from_secs(30))
-            .user_agent("NextcloudAuth/0.1.0")
+            .user_agent(concat!("NextcloudAuth/", env!("CARGO_PKG_VERSION")))
             .pool_idle_timeout(std::time::Duration::from_secs(90))
             .pool_max_idle_per_host(4)
             .build()
@@ -89,7 +89,10 @@ impl NextcloudAuthService {
         let response = client
             .post(poll_url)
             .form(&[("token", token)])
-            .header("User-Agent", "NextcloudAuth/0.1.0")
+            .header(
+                "User-Agent",
+                concat!("NextcloudAuth/", env!("CARGO_PKG_VERSION")),
+            )
             .header("Accept", "application/json")
             .send()
             .await

--- a/nextcloud-auth/src/service.rs
+++ b/nextcloud-auth/src/service.rs
@@ -89,10 +89,6 @@ impl NextcloudAuthService {
         let response = client
             .post(poll_url)
             .form(&[("token", token)])
-            .header(
-                "User-Agent",
-                concat!("NextcloudAuth/", env!("CARGO_PKG_VERSION")),
-            )
             .header("Accept", "application/json")
             .send()
             .await

--- a/photo-gallery/Cargo.toml
+++ b/photo-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo-gallery"
-version = "0.2.0"
+version.workspace = true
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A reusable photo gallery management library with thumbnail generation and storage"

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -12,6 +12,9 @@ pub fn HomeScreen(on_navigate: EventHandler<Screen>) -> Element {
     let spacetimedb_ctx = use_spacetimedb_context();
     let connection_state = spacetimedb_ctx.state;
 
+    let app_version = env!("CARGO_PKG_VERSION");
+    let git_commit = option_env!("GIT_COMMIT_HASH").unwrap_or("dev");
+
     // Initialize database on mount
     use_effect(move || {
         // Database initialization is now handled by SpacetimeDB context
@@ -70,6 +73,14 @@ pub fn HomeScreen(on_navigate: EventHandler<Screen>) -> Element {
                         p {
                             strong { "Arch: " }
                             "{std::env::consts::ARCH}"
+                        }
+                        p {
+                            strong { "Version: " }
+                            "{app_version}"
+                        }
+                        p {
+                            strong { "Commit: " }
+                            "{git_commit}"
                         }
                         p {
                             {

--- a/stalltagebuch-server/Cargo.toml
+++ b/stalltagebuch-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stalltagebuch-server"
-version.workspace = true
+version = "0.2.1"
 edition = "2024"
 description = "SpacetimeDB server module for Stalltagebuch"
 license = "MIT OR Apache-2.0"

--- a/stalltagebuch-server/Cargo.toml
+++ b/stalltagebuch-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stalltagebuch-server"
-version = "0.2.0"
+version.workspace = true
 edition = "2024"
 description = "SpacetimeDB server module for Stalltagebuch"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Centralize version in `[workspace.package]` and inherit it in all sub-crates via `version.workspace = true`
- Add `build.rs` to capture the short git commit hash at build time as `GIT_COMMIT_HASH` env var
- Display app version and commit hash on the home screen
- Use `CARGO_PKG_VERSION` dynamically in nextcloud-auth user-agent strings instead of a hardcoded value
- Bump version to 0.2.1